### PR TITLE
Removes `patterns` missing since Django 1.10

### DIFF
--- a/src/proxy/urls.py
+++ b/src/proxy/urls.py
@@ -1,12 +1,12 @@
-from django.conf.urls import patterns, include, url
+from django.conf.urls import include, url
 from django.contrib import admin
 
 from proxyapp.views import TestProxyView
 
-urlpatterns = patterns('',
+urlpatterns = [
     # Examples:
     # url(r'^$', 'proxy.views.home', name='home'),
     # url(r'^blog/', include('blog.urls')),
 
     url(r'^(?P<path>.*)$', TestProxyView.as_view()),
-)
+]


### PR DESCRIPTION
`patterns` was deprecated in Django 1.8

From https://docs.djangoproject.com/en/1.11/releases/1.10/, "django.conf.urls.patterns() is removed."